### PR TITLE
Fix: Ignore decoding JSON when content length is unknown

### DIFF
--- a/chronos/client.go
+++ b/chronos/client.go
@@ -95,7 +95,7 @@ func (client *Client) apiCall(method string, uri string, queryParams map[string]
 		return 0, err
 	}
 
-	if response.ContentLength > 0 {
+	if response.ContentLength != 0 {
 		err = json.NewDecoder(response.Body).Decode(result)
 
 		if err != nil {


### PR DESCRIPTION
As you can see (https://golang.org/src/net/http/transfer.go#42) the Content
  length value "-1" is considered as unknown and should not be considered
  as invalid when decoding the structure.