### PR TITLE
update paths for v3 support

### DIFF
--- a/chronos/const.go
+++ b/chronos/const.go
@@ -2,9 +2,9 @@ package chronos
 
 // Constants defining the various chronos endpoints
 const (
-	ChronosAPIJob             = "scheduler/job"
-	ChronosAPIJobs            = "scheduler/jobs"
-	ChronosAPIKillJobTask     = "scheduler/task/kill"
-	ChronosAPIAddScheduledJob = "scheduler/iso8601"
-	ChronosAPIAddDependentJob = "scheduler/dependency"
+	ChronosAPIJob             = "v1/scheduler/job"
+	ChronosAPIJobs            = "v1/scheduler/jobs"
+	ChronosAPIKillJobTask     = "v1/scheduler/task/kill"
+	ChronosAPIAddScheduledJob = "v1/scheduler/iso8601"
+	ChronosAPIAddDependentJob = "v1/scheduler/dependency"
 )


### PR DESCRIPTION
as documented here: https://github.com/mesos/chronos/releases/tag/v3.0.0