### PR TITLE
Changing Constraints format to match go-marathon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 */*.coverprofile
+*~
+vendor/*/
+# intellij files
+.idea
+*.iml

--- a/chronos/client_test.go
+++ b/chronos/client_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Client", func() {
 		It("Returns a new client", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/scheduler/jobs"),
+					ghttp.VerifyRequest("GET", "/v1/scheduler/jobs"),
 				),
 			)
 
@@ -48,7 +48,7 @@ var _ = Describe("Client", func() {
 		It("Errors if it cannot hit chronos", func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/scheduler/jobs"),
+					ghttp.VerifyRequest("GET", "/v1/scheduler/jobs"),
 					ghttp.RespondWith(http.StatusInternalServerError, nil),
 				),
 			)

--- a/chronos/jobs.go
+++ b/chronos/jobs.go
@@ -44,7 +44,7 @@ type Job struct {
 	Container              *Container          `json:"container,omitempty"`
 	Schedule               string              `json:"schedule,omitempty"`
 	ScheduleTimeZone       string              `json:"scheduleTimeZone,omitempty"`
-	Constraints            []map[string]string `json:"constraints,omitempty"`
+	Constraints            [][]string          `json:"constraints,omitempty"`
 	Parents                []string            `json:"parents,omitempty"`
 }
 

--- a/chronos/jobs_test.go
+++ b/chronos/jobs_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Jobs", func() {
 		server = ghttp.NewServer()
 		server.AppendHandlers(
 			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("GET", "/scheduler/jobs"),
+				ghttp.VerifyRequest("GET", "/v1/scheduler/jobs"),
 			),
 		)
 
@@ -46,7 +46,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("GET", "/scheduler/jobs"),
+					ghttp.VerifyRequest("GET", "/v1/scheduler/jobs"),
 					ghttp.RespondWith(http.StatusOK, `[
 						{
 							"name":"dockerjob",
@@ -84,7 +84,8 @@ var _ = Describe("Jobs", func() {
 								"parameters":[]
 							},
 							"schedule":"R/2015-05-21T18:14:00.000Z/PT2M",
-							"scheduleTimeZone":""
+							"scheduleTimeZone":"",
+							"constraints":[["rack", "EQUALS", "rack-1"]]
 						}
           ]`),
 				),
@@ -129,6 +130,7 @@ var _ = Describe("Jobs", func() {
 						Volumes:    []map[string]string{},
 						Parameters: []map[string]string{},
 					},
+					Constraints:          [][]string{[]string{"rack", "EQUALS", "rack-1"}},
 				},
 			}))
 		})
@@ -142,7 +144,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("DELETE", "/scheduler/job/"+jobName),
+					ghttp.VerifyRequest("DELETE", "/v1/scheduler/job/"+jobName),
 					ghttp.RespondWith(http.StatusOK, nil),
 				),
 			)
@@ -162,7 +164,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("DELETE", "/scheduler/task/kill/"+jobName),
+					ghttp.VerifyRequest("DELETE", "/v1/scheduler/task/kill/"+jobName),
 					ghttp.RespondWith(http.StatusOK, nil),
 				),
 			)
@@ -183,7 +185,7 @@ var _ = Describe("Jobs", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("PUT", "/scheduler/job/"+jobName, ""),
+						ghttp.VerifyRequest("PUT", "/v1/scheduler/job/"+jobName, ""),
 						ghttp.RespondWith(http.StatusOK, nil),
 					),
 				)
@@ -199,7 +201,7 @@ var _ = Describe("Jobs", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(
 					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("PUT", "/scheduler/job/"+jobName, "arg1=value1&arg2=value2"),
+						ghttp.VerifyRequest("PUT", "/v1/scheduler/job/"+jobName, "arg1=value1&arg2=value2"),
 						ghttp.RespondWith(http.StatusOK, nil),
 					),
 				)
@@ -221,7 +223,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("POST", "/scheduler/iso8601"),
+					ghttp.VerifyRequest("POST", "/v1/scheduler/iso8601"),
 					ghttp.VerifyJSONRepresenting(Job{}),
 					ghttp.RespondWith(http.StatusOK, nil),
 				),
@@ -239,7 +241,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("POST", "/scheduler/dependency"),
+					ghttp.VerifyRequest("POST", "/v1/scheduler/dependency"),
 					ghttp.VerifyJSONRepresenting(Job{}),
 					ghttp.RespondWith(http.StatusOK, nil),
 				),
@@ -257,7 +259,7 @@ var _ = Describe("Jobs", func() {
 		BeforeEach(func() {
 			server.AppendHandlers(
 				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("POST", "/scheduler/iso8601"),
+					ghttp.VerifyRequest("POST", "/v1/scheduler/iso8601"),
 					ghttp.VerifyJSON(`{"name":"","command":"","epsilon":"PT10M","schedule":"R1//PT2M"}`),
 					ghttp.RespondWith(http.StatusOK, nil),
 				),

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,70 @@
+hash: 1eabecd33272da89523bc3b7d6384ea8d6d8c078c5128a6e1bec165e99c9516a
+updated: 2018-02-11T17:37:03.832509118-05:00
+imports: []
+testImports:
+- name: github.com/golang/protobuf
+  version: 4bd1920723d7b7c925de087aa32e2187708897f7
+  subpackages:
+  - proto
+- name: github.com/onsi/ginkgo
+  version: 9eda700730cba42af70d53180f9dcce9266bc2bc
+  subpackages:
+  - config
+  - internal/codelocation
+  - internal/containernode
+  - internal/failer
+  - internal/leafnodes
+  - internal/remote
+  - internal/spec
+  - internal/spec_iterator
+  - internal/specrunner
+  - internal/suite
+  - internal/testingtproxy
+  - internal/writer
+  - reporters
+  - reporters/stenographer
+  - reporters/stenographer/support/go-colorable
+  - reporters/stenographer/support/go-isatty
+  - types
+- name: github.com/onsi/gomega
+  version: 003f63b7f4cff3fc95357005358af2de0f5fe152
+  subpackages:
+  - format
+  - ghttp
+  - internal/assertion
+  - internal/asyncassertion
+  - internal/oraclematcher
+  - internal/testingtsupport
+  - matchers
+  - matchers/support/goraph/bipartitegraph
+  - matchers/support/goraph/edge
+  - matchers/support/goraph/node
+  - matchers/support/goraph/util
+  - types
+- name: golang.org/x/net
+  version: 01256db42e5106196a3473ec1620727a383500e8
+  subpackages:
+  - html
+  - html/atom
+  - html/charset
+- name: golang.org/x/sys
+  version: e48874b42435b4347fc52bdee0424a52abc974d7
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 4e4a3210bb54bb31f6ab2cdca2edcc0b50c420c1
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/internal
+  - encoding/internal/identifier
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - internal/utf8internal
+  - runes
+  - transform
+- name: gopkg.in/yaml.v2
+  version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b


### PR DESCRIPTION
Updating Job.Constraints to be a `[][]string` instead of an `[]map[string]string` to reflect the reality that constraints are usually applied in groups of 3, not 2.

Also,
* Added glide.lock from current glide version (no package upgrades)
* Unit tests are now passing again
* Updated .gitignore
