### PR TITLE
Travis CI and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+go_import_path: github.com/behance/go-chronos
+language: go
+sudo: false
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get github.com/Masterminds/glide
+  - go get github.com/golang/lint/golint
+  - glide install
+before_script:
+  - golint -set_exit_status $(go list ./...)
+  - go vet ./...
+script:
+  - rm -rf examples # because the examples are hard-coded to import github.com/behance/go-chronos/chronos and so fails with forks
+  - $GOPATH/bin/goveralls -service=travis-ci

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/behance/go-chronos.svg?branch=master)](https://travis-ci.org/behance/go-chronos)
+
 # go-chronos
 
 Go wrapper for the chronos API.


### PR DESCRIPTION
Add support for Travis CI and Coveralls

so we can see at a glance whether PR is passing tests or not and how we're doing on coverage

Sample passing CI job: https://travis-ci.org/msabramo/go-chronos/builds/340346044

**Note: We will need to register github.com/behance/go-chronos in the UIs of Travis CI and Coveralls.io**