### PR TITLE
Allow API prefix to be specified in client config

### DIFF
--- a/chronos/client.go
+++ b/chronos/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 )
@@ -111,14 +112,14 @@ func (client *Client) apiCall(method string, uri string, queryParams map[string]
 	return status, nil
 }
 
-func (client *Client) buildURL(path string, queryParams map[string]string) {
+func (client *Client) buildURL(uri string, queryParams map[string]string) {
 	query := client.url.Query()
 	for k, v := range queryParams {
 		query.Add(k, v)
 	}
 	client.url.RawQuery = query.Encode()
 
-	client.url.Path = path
+	client.url.Path = path.Join(client.config.APIPrefix, uri)
 }
 
 // TODO: think about pulling out a Request struct/object/thing

--- a/chronos/client_test.go
+++ b/chronos/client_test.go
@@ -24,6 +24,7 @@ var _ = Describe("Client", func() {
 			URL:            server.URL(),
 			Debug:          false,
 			RequestTimeout: 5,
+			APIPrefix:      "v1",
 		}
 	})
 
@@ -55,6 +56,22 @@ var _ = Describe("Client", func() {
 
 			_, err := NewClient(config_stub)
 			Expect(err).To(MatchError("Could not reach chronos cluster: 500 Internal Server Error"))
+		})
+
+		It("Gracefully handles no API prefix", func() {
+			server.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/scheduler/jobs"),
+				),
+			)
+
+			config_stub = NewDefaultConfig()
+			config_stub.URL = server.URL()
+
+			client, err := NewClient(config_stub)
+
+			Expect(client).To(BeAssignableToTypeOf(new(Client)))
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/chronos/config.go
+++ b/chronos/config.go
@@ -8,6 +8,8 @@ type Config struct {
 	Debug bool
 	/* the timeout for requests */
 	RequestTimeout int
+	/* string to prefix api paths with */
+	APIPrefix string
 }
 
 // NewDefaultConfig returns a default configuration.
@@ -16,5 +18,7 @@ func NewDefaultConfig() Config {
 	return Config{
 		URL:            "http://127.0.0.1:4400",
 		Debug:          false,
-		RequestTimeout: 5}
+		RequestTimeout: 5,
+		APIPrefix:      "",
+	}
 }

--- a/chronos/const.go
+++ b/chronos/const.go
@@ -2,9 +2,9 @@ package chronos
 
 // Constants defining the various chronos endpoints
 const (
-	ChronosAPIJob             = "v1/scheduler/job"
-	ChronosAPIJobs            = "v1/scheduler/jobs"
-	ChronosAPIKillJobTask     = "v1/scheduler/task/kill"
-	ChronosAPIAddScheduledJob = "v1/scheduler/iso8601"
-	ChronosAPIAddDependentJob = "v1/scheduler/dependency"
+	ChronosAPIJob             = "scheduler/job"
+	ChronosAPIJobs            = "scheduler/jobs"
+	ChronosAPIKillJobTask     = "scheduler/task/kill"
+	ChronosAPIAddScheduledJob = "scheduler/iso8601"
+	ChronosAPIAddDependentJob = "scheduler/dependency"
 )

--- a/chronos/jobs_test.go
+++ b/chronos/jobs_test.go
@@ -31,6 +31,7 @@ var _ = Describe("Jobs", func() {
 			URL:            server.URL(),
 			Debug:          false,
 			RequestTimeout: 5,
+			APIPrefix:      "v1",
 		}
 
 		// This will make a request and I dont know how to reset it


### PR DESCRIPTION
Chronos has built divergent releases: 2.5.x and 3.x. V3 has prefixed the existing v1/v2 APIs with a leading /v1 to separate from the new, incompatible APIs. https://github.com/mesos/chronos/releases

Flight Director / Ethos needs to be able to support both, so the APIPrefix is now directly configurable.

CC: @digitalyuki 